### PR TITLE
Allow the user to specify a metric prefix

### DIFF
--- a/Fsd.go
+++ b/Fsd.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	address string
+	prefix  = ""
 
 	addressConfig chan *etcd.Response
 	outgoing      = make(chan []byte, 100000)
@@ -24,6 +25,11 @@ var (
 
 	conn net.Conn
 )
+
+func InitWithPrefixAndDynamicConfig(metricPrefix string, client *etcd.Client, hostname string) {
+	prefix = metricPrefix + "."
+	InitWithDynamicConfig(client, hostname)
+}
 
 func InitWithDynamicConfig(client *etcd.Client, hostname string) {
 	addressConfig = make(chan *etcd.Response)
@@ -201,7 +207,7 @@ func Set(name string, value float64) {
 
 func createPayload(name string, value float64, suffix string) string {
 	// we spend a lot of time in this code
-	return name + ":" + strconv.FormatFloat(value, 'f', -1, 64) + "|" + suffix
+	return prefix + name + ":" + strconv.FormatFloat(value, 'f', -1, 64) + "|" + suffix
 	//return fmt.Sprintf("%s:%f|%s", name, value, suffix)
 }
 


### PR DESCRIPTION
It's handy to specify a prefix once and then not have to write it each time you send a particular metric.